### PR TITLE
feat (route): inserting contato

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,12 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@fnando/cnpj": "^2.0.0",
         "@prisma/client": "^6.7.0",
         "dotenv": "^16.5.0",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "uuid": "^11.1.0",
+        "zod": "^3.24.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
@@ -600,6 +603,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fnando/cnpj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@fnando/cnpj/-/cnpj-2.0.0.tgz",
+      "integrity": "sha512-jrkOX+4t7/EdDeNurlPPq8Eum8XW5ebStmMfrOF0XrSRO+Jo1Hb1+bA8rzwQs3REwtqhlsztOrlbljOy/pyOFA==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2931,6 +2940,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2989,7 +3011,6 @@
       "version": "3.24.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@fnando/cnpj": "^2.0.0",
     "@prisma/client": "^6.7.0",
     "dotenv": "^16.5.0",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "uuid": "^11.1.0",
+    "zod": "^3.24.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/src/middlewares/sanitizeCNPJ.js
+++ b/src/middlewares/sanitizeCNPJ.js
@@ -1,4 +1,4 @@
-const { sanitizeCNPJ } = require('../utils/sanitize');
+const sanitizeCNPJ = require('../utils/sanitizeCNPJ');
 
 function sanitizeCNPJMiddleware(req, res, next) {
   if (req.body && req.body.cnpj) {

--- a/src/middlewares/validateContato.js
+++ b/src/middlewares/validateContato.js
@@ -1,0 +1,23 @@
+const { z } = require('zod');
+const cnpj = require('@fnando/cnpj');
+
+const contatoSchema = z.object({
+  nome: z.string().min(1, 'Nome é obrigatório'),
+  email: z.string().email('Email é inválido'),
+  cnpj: z
+    .string()
+    .refine((val) => cnpj.isValid(val), { message: 'CNPJ inválido' }),
+});
+
+function validateContato(req, res, next) {
+  const result = contatoSchema.safeParse(req.body);
+
+  if (!result.success) {
+    const errors = result.error.issues.map((issue) => issue.message);
+    return res.status(400).json({ error: errors });
+  }
+
+  next();
+}
+
+module.exports = validateContato;


### PR DESCRIPTION
**Motivação**  
Garantir a validação e sanitização adequadas dos dados recebidos pela API de contatos, prevenindo inserção de informações inválidas, como CNPJs malformados, e evitando duplicidade de registros. Com isso, melhora-se a robustez, integridade e clareza na resposta da API.

**O que foi feito**  
- ✅ Adicionadas as dependências `@fnando/cnpj` (para validação e formatação de CNPJ) e `zod` (para schema validation);
- ✅ Criado o middleware `validateContato.js` com `zod`, incluindo validações para `nome`, `email` e `cnpj`;
- ✅ Corrigido o middleware `sanitizeCNPJ.js` com importação direta da função `sanitizeCNPJ`;
- ✅ Implementada a rota `POST /contatos` com:
  - Encadeamento dos middlewares de sanitização e validação;
  - Tratamento do erro `P2002` do Prisma (registro duplicado), retornando status `409 Conflict`;
- ✅ Melhorada a mensagem de erro da rota `DELETE /contatos/:id` ao lidar com UUIDs inválidos;
- ✅ Preparada a base da rota `PUT /contatos/:id` para futura implementação.

**Impacto esperado**  
- Validação robusta dos dados recebidos via API;
- Respostas mais precisas e adequadas em caso de erro;
- Prevenção de dados duplicados no banco;
- Código mais modular e reutilizável, com lógica de validação separada em middleware.

